### PR TITLE
Touch region examples

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import {
 import Examples from "./src/Examples";
 import VolumeSlider from "./src/VolumeSlider";
 import TextContrast from "./src/TextContrast";
+import TouchRegion from "./src/TouchRegion";
 import { createStackNavigator } from "./src/utils";
 
 const { LightTheme, DarkTheme } = adaptNavigationTheme({
@@ -54,6 +55,7 @@ export default function App() {
           <Stack.Screen name="Accessibility Examples" component={Examples} />
           <Stack.Screen name="Volume Slider" component={VolumeSlider} />
           <Stack.Screen name="Text Contrast" component={TextContrast} />
+          <Stack.Screen name="Touch Region" component={TouchRegion} />
         </Stack.Navigator>
       </NavigationContainer>
     </PaperProvider>

--- a/src/Examples.tsx
+++ b/src/Examples.tsx
@@ -6,6 +6,7 @@ import { RootStackParamList, useNavigation } from "./utils";
 const routes = [
   "Text Contrast",
   "Volume Slider",
+  "Touch Region",
 ] as const satisfies readonly (keyof RootStackParamList)[];
 export default function Examples() {
   const navigation = useNavigation();

--- a/src/TextContrast.tsx
+++ b/src/TextContrast.tsx
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
   screen: {
     alignSelf: "center",
     maxWidth: 400,
-    width: 400,
+    width: "100%",
     paddingHorizontal: 24,
   },
   card: {

--- a/src/TouchRegion.tsx
+++ b/src/TouchRegion.tsx
@@ -49,6 +49,9 @@ function AccessibleStarHitSlop() {
     <Pressable
       style={styles.pressable}
       onPress={() => setIsStarred((value) => !value)}
+      aria-label={isStarred ? "Remove from favorites" : "Add to favorites"}
+      role="button"
+      hitSlop={24}
     >
       <MaterialCommunityIcons
         size={20}

--- a/src/TouchRegion.tsx
+++ b/src/TouchRegion.tsx
@@ -12,6 +12,18 @@ export default function TouchRegionRoute() {
           <InaccessibleStar />
         </Card.Content>
       </Card>
+      <Card style={styles.card}>
+        <Card.Title title="Accessible (variant 1)" />
+        <Card.Content>
+          <AccessibleStarHitSlop />
+        </Card.Content>
+      </Card>
+      <Card style={styles.card}>
+        <Card.Title title="Accessible (variant 2)" />
+        <Card.Content>
+          <AccessibleStarLarger />
+        </Card.Content>
+      </Card>
     </View>
   );
 }
@@ -31,11 +43,41 @@ function InaccessibleStar() {
   );
 }
 
+function AccessibleStarHitSlop() {
+  const [isStarred, setIsStarred] = useState(false);
+  return (
+    <Pressable
+      style={styles.pressable}
+      onPress={() => setIsStarred((value) => !value)}
+    >
+      <MaterialCommunityIcons
+        size={20}
+        name={isStarred ? "star-remove" : "star"}
+      />
+    </Pressable>
+  );
+}
+
+function AccessibleStarLarger() {
+  const [isStarred, setIsStarred] = useState(false);
+  return (
+    <Pressable
+      style={styles.pressable}
+      onPress={() => setIsStarred((value) => !value)}
+    >
+      <MaterialCommunityIcons
+        size={20}
+        name={isStarred ? "star-remove" : "star"}
+      />
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   screen: {
     alignSelf: "center",
     maxWidth: 400,
-    width: 400,
+    width: "100%",
     paddingHorizontal: 24,
   },
   card: {

--- a/src/TouchRegion.tsx
+++ b/src/TouchRegion.tsx
@@ -65,11 +65,13 @@ function AccessibleStarLarger() {
   const [isStarred, setIsStarred] = useState(false);
   return (
     <Pressable
-      style={styles.pressable}
+      style={[styles.pressable, styles.largerPressable]}
       onPress={() => setIsStarred((value) => !value)}
+      aria-label={isStarred ? "Remove from favorites" : "Add to favorites"}
+      role="button"
     >
       <MaterialCommunityIcons
-        size={20}
+        size={40}
         name={isStarred ? "star-remove" : "star"}
       />
     </Pressable>
@@ -95,5 +97,9 @@ const styles = StyleSheet.create({
     backgroundColor: "#c0b755",
     alignSelf: "center",
     marginHorizontal: 4,
+  },
+  largerPressable: {
+    width: 48,
+    height: 48,
   },
 });

--- a/src/TouchRegion.tsx
+++ b/src/TouchRegion.tsx
@@ -1,0 +1,54 @@
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useState } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Card } from "react-native-paper";
+
+export default function TouchRegionRoute() {
+  return (
+    <View style={styles.screen}>
+      <Card style={styles.card}>
+        <Card.Title title="Inaccessible" />
+        <Card.Content>
+          <InaccessibleStar />
+        </Card.Content>
+      </Card>
+    </View>
+  );
+}
+
+function InaccessibleStar() {
+  const [isStarred, setIsStarred] = useState(false);
+  return (
+    <Pressable
+      style={styles.pressable}
+      onPress={() => setIsStarred((value) => !value)}
+    >
+      <MaterialCommunityIcons
+        size={20}
+        name={isStarred ? "star-remove" : "star"}
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    alignSelf: "center",
+    maxWidth: 400,
+    width: 400,
+    paddingHorizontal: 24,
+  },
+  card: {
+    marginTop: 18,
+  },
+  pressable: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 4,
+    backgroundColor: "#c0b755",
+    alignSelf: "center",
+    marginHorizontal: 4,
+  },
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ export type RootStackParamList = {
   "Accessibility Examples": undefined;
   "Volume Slider": undefined;
   "Text Contrast": undefined;
+  "Touch Region": undefined;
 };
 
 export const createStackNavigator =


### PR DESCRIPTION
Buttons that are too small to touch are considered inaccessible. A touchable component should have a touch area of at least 48x48.

The inaccessible example is of a button that is 24x24, very hard to hit.
Then we have two accessible options:
  - one that uses the `hitSlop` prop which increases the touch area without changing the way the button looks
  - one that is simply bigger

## Screen readers

### iOS

The `hitSlop` prop affects screen reader functionality, you can tap outside of the button and VoiceOver will detect as if you've tapped on it. When you interact with a mouse while VoiceOver is enabled the focus will be shifted as soon as you reach the touch area (video has sound):


https://user-images.githubusercontent.com/8790386/231187656-84b59186-1e31-4517-93d2-deee0ffa1a5c.MP4

### Android

The `hitSlop` prop doesn't affect the UX when using TalkBack, yet. Tapping outside of the button but in the hit slop area doesn't focus it. Accessibility Scanner reports a false positive of a too small touch area (the touch area without the hit slop). When using a mouse pointer when tapping outside of the button but in the hit slop area the `onPress` handler is triggered but the TalkBack focus doesn't change.
Related issue: https://github.com/facebook/react-native/issues/32089

![Accessibility Scanner reports a false positive of a too small touch area](https://user-images.githubusercontent.com/8790386/231189857-598b494c-cb7e-4204-8c60-0f54262015af.jpg)

